### PR TITLE
Refactor leaveProfession method and delete player's profession from t…

### DIFF
--- a/src/main/java/org/vac/professionplugin/ProfessionDataBase.java
+++ b/src/main/java/org/vac/professionplugin/ProfessionDataBase.java
@@ -159,29 +159,30 @@ public class ProfessionDataBase
     {
         try
         {
-            getPlayerProfession(player).leaveProfession();
-
-            String query =
-                    "DELETE " +
-                    "FROM player_professions " +
-                    "WHERE player_uuid = ?";
-            // Eliminar la información de la profesión del jugador en la base de datos
-            PreparedStatement statement = connection.prepareStatement(
-                    "DELETE FROM player_professions WHERE player_uuid = ?"
-            );
-            statement.setString(1, player.getUniqueId().toString());
-            int rowsAffected = statement.executeUpdate();
-            statement.close();
-
-            if (rowsAffected > 0)
+            Profession profession = getPlayerProfession(player);
+            if (profession != null)
             {
-                player.sendMessage(ChatColor.GREEN + "¡Has dejado tu profesión!");
+                profession.leaveProfession();
+
+                String query =
+                                "DELETE " +
+                                "FROM player_professions " +
+                                "WHERE player_uuid = ?";
+                // Eliminar la información de la profesión del jugador en la base de datos
+                PreparedStatement statement = connection.prepareStatement(query);
+                statement.setString(1, player.getUniqueId().toString());
+                int rowsAffected = statement.executeUpdate();
+
+                if (rowsAffected > 0)
+                {
+                    player.sendMessage(ChatColor.GREEN + "¡Has dejado tu profesión!");
+                }
+                statement.close();
             }
             else
             {
                 player.sendMessage(ChatColor.RED + "¡No tienes una profesión que dejar!");
             }
-            statement.close();
         }
         catch (SQLException e)
         {


### PR DESCRIPTION
…he database

- Refactored the leaveProfession method in ProfessionDataBase class to use a local variable for getPlayerProfession(player) instead of calling it twice.
- Updated the code to check if profession is not null before leaving the profession and deleting it from the database.
- Moved the deletion query into a separate string variable for better readability.
- Closed the PreparedStatement after executing it.

This commit improves code efficiency and readability when leaving a profession and deleting it from the database.